### PR TITLE
add returned() assertion

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2020 James Garbutt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,17 @@ export class Stub<T extends FunctionLike> {
         call.args.every((arg, idx) => args[idx] === arg)
     );
   }
+
+  /**
+   * Asserts that the stub returned a given value
+   * @param val Value to check for
+   * @return Whether the value was ever returned or not
+   */
+  public returned(val: ReturnType<T>): boolean {
+    return [...this.calls].some(
+      (call) => call.returnValue === val
+    );
+  }
 }
 
 type StubbedFunction<T> = T extends FunctionLike ? T : FunctionLike;

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -11,6 +11,15 @@ describe('Stub', () => {
     });
   });
 
+  describe('returned', () => {
+    it('should determine if stub returned a given value', () => {
+      const stub = lib.stub((x: number) => x + x);
+      stub.handler(5);
+      expect(stub.returned(10)).to.equal(true);
+      expect(stub.returned(5)).to.equal(false);
+    });
+  });
+
   describe('calledWith', () => {
     it('should determine if stub was called with args', () => {
       const stub = lib.spy();


### PR DESCRIPTION
simply asserts that a given stub returned a value at some point:

```ts
stub.returned(5); // true or false depending on if the handler ever returned 5
```