### PR TITLE
stub functions by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Creates a single "spy" function to be used as input into some other
 function.
 
 ```ts
-const test = spy();
-window.addEventListener('load', test.handler);
-test.called; // true once the event fires
+const spy = hanbi.spy();
+window.addEventListener('load', spy.handler);
+spy.called; // true once the event fires
 ```
 
 ## `stub(fn)`
@@ -30,9 +30,9 @@ Creates a wrapped version of a given function which tracks any calls.
 
 ```ts
 const fn = () => 5;
-const test = stub(fn);
-test.handler(); // 5
-test.called; // true
+const stub = hanbi.stub(fn);
+stub.handler(); // 5
+stub.called; // true
 ```
 
 ## `stubMethod(obj, method)`
@@ -46,9 +46,9 @@ class Foo {
   }
 }
 const instance = new Foo();
-const test = stubMethod(instance, 'myMethod');
+const stub = hanbi.stubMethod(instance, 'myMethod');
 instance.myMethod(); // undefined
-test.called; // true
+stub.called; // true
 ```
 
 # Stub API

--- a/src/main.ts
+++ b/src/main.ts
@@ -163,9 +163,7 @@ export class Stub<T extends FunctionLike> {
    * @return Whether the value was ever returned or not
    */
   public returned(val: ReturnType<T>): boolean {
-    return [...this.calls].some(
-      (call) => call.returnValue === val
-    );
+    return [...this.calls].some((call) => call.returnValue === val);
   }
 }
 
@@ -197,14 +195,11 @@ export function stubMethod<TObj, TKey extends keyof TObj>(
 
 /**
  * Stubs a given function.
- * By default, behaves like a "spy" as pass-through to the original function
- * is automatically enabled.
  * @param fn Function to stub
  * @return Stubbed function
  */
 export function stub<T extends FunctionLike>(fn: T): Stub<T> {
   const result = new Stub<T>(fn);
-  result.passThrough();
   return result;
 }
 

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -14,6 +14,7 @@ describe('Stub', () => {
   describe('returned', () => {
     it('should determine if stub returned a given value', () => {
       const stub = lib.stub((x: number) => x + x);
+      stub.passThrough();
       stub.handler(5);
       expect(stub.returned(10)).to.equal(true);
       expect(stub.returned(5)).to.equal(false);
@@ -250,15 +251,15 @@ describe('spy', () => {
 });
 
 describe('stub', () => {
-  it('should pass through by default', () => {
+  it('should stub a function', () => {
     const fn = (): number => 1500;
     const stub = lib.stub(fn);
-    expect(stub.handler()).to.equal(1500);
+    expect(stub.handler()).to.equal(undefined);
     expect(stub.original).to.equal(fn);
     expect([...stub.calls]).to.deep.equal([
       {
         args: [],
-        returnValue: 1500
+        returnValue: undefined
       }
     ]);
   });


### PR DESCRIPTION
this removes the passThrough behaviour i had as a default before.

seems to make more sense this way as we are in fact trying to _stub_ a function, not _spy_ on it.

a spy can be achieved by then calling `passThrough()`..