### PR TITLE
support thisValue in calls

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -82,8 +82,13 @@ export class Stub<T extends FunctionLike> {
    */
   public constructor(fn: T) {
     this.original = fn;
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
-    this.handler = function (this: unknown, ...args: Parameters<T>): ReturnType<T> | undefined {
+    this.handler = function handler(
+      this: unknown,
+      ...args: Parameters<T>
+    ): ReturnType<T> | undefined {
+      // eslint-disable-next-line no-invalid-this
       return self._handleCall.call(self, this, args);
     } as T;
   }
@@ -94,7 +99,10 @@ export class Stub<T extends FunctionLike> {
    * @param args Arguments passed when being called
    * @return Return value of this call
    */
-  protected _handleCall(thisValue: unknown, args: Parameters<T>): ReturnType<T> | undefined {
+  protected _handleCall(
+    thisValue: unknown,
+    args: Parameters<T>
+  ): ReturnType<T> | undefined {
     const returnValue = this._returnFunction
       ? this._returnFunction(...args)
       : this._returnValue;

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -48,6 +48,7 @@ describe('Stub', () => {
       stub.handler(2);
       expect(stub.firstCall).to.deep.equal({
         args: [1],
+        thisValue: stub,
         returnValue: undefined
       });
     });
@@ -60,6 +61,7 @@ describe('Stub', () => {
       stub.handler(2);
       expect(stub.lastCall).to.deep.equal({
         args: [2],
+        thisValue: stub,
         returnValue: undefined
       });
     });
@@ -73,10 +75,12 @@ describe('Stub', () => {
 
       expect(stub.getCall(0)).to.deep.equal({
         args: [1],
+        thisValue: stub,
         returnValue: undefined
       });
       expect(stub.getCall(1)).to.deep.equal({
         args: [2],
+        thisValue: stub,
         returnValue: undefined
       });
     });
@@ -93,10 +97,12 @@ describe('Stub', () => {
       expect([...stub.calls]).to.deep.equal([
         {
           args: [1, 2, 3],
+          thisValue: stub,
           returnValue: undefined
         },
         {
           args: ['foo'],
+          thisValue: stub,
           returnValue: undefined
         }
       ]);
@@ -109,6 +115,7 @@ describe('Stub', () => {
       expect([...stub.calls]).to.deep.equal([
         {
           args: [],
+          thisValue: stub,
           returnValue: 1209
         }
       ]);
@@ -180,6 +187,7 @@ describe('Stub', () => {
       expect([...stub.calls]).to.deep.equal([
         {
           args: [],
+          thisValue: stub,
           returnValue: undefined
         }
       ]);
@@ -240,10 +248,12 @@ describe('spy', () => {
     expect([...spy.calls]).to.deep.equal([
       {
         args: [1, 2, 3],
+        thisValue: spy,
         returnValue: undefined
       },
       {
         args: [],
+        thisValue: spy,
         returnValue: undefined
       }
     ]);
@@ -265,6 +275,7 @@ describe('stub', () => {
     expect([...stub.calls]).to.deep.equal([
       {
         args: [],
+        thisValue: stub,
         returnValue: undefined
       }
     ]);
@@ -288,6 +299,26 @@ describe('stubMethod', () => {
     expect([...stub.calls]).to.deep.equal([
       {
         args: [],
+        thisValue: stub,
+        returnValue: undefined
+      }
+    ]);
+  });
+
+  it('should track thisValue', () => {
+    const Klass = class {
+      public someMethod(): number {
+        return 105;
+      }
+    };
+    const instance = new Klass();
+    const stub = lib.stubMethod(instance, 'someMethod');
+
+    instance.someMethod();
+    expect([...stub.calls]).to.deep.equal([
+      {
+        args: [],
+        thisValue: instance,
         returnValue: undefined
       }
     ]);


### PR DESCRIPTION
So you can access the `this` at the time the call was made:

```ts
const spy = hanbi.stubMethod(Foo.prototype, 'someMethod');
const instance = new Foo();
instance.someMethod();
spy.getCall(0).thisValue === instance;
```