### PR TITLE
add types field to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A small javascript library for stubbing and spying on methods/functions.",
   "type": "module",
+  "types": "./lib/main.d.ts",
   "main": "./lib/cjs/main.cjs",
   "module": "./lib/main.js",
   "exports": {


### PR DESCRIPTION
There's a bug in 1.0.0 which means commonjs consumers dont get types.

for now i explicitly added it here